### PR TITLE
Fix compile errors with -DQUIET.

### DIFF
--- a/message.h
+++ b/message.h
@@ -12,6 +12,10 @@ void fatal_error (const char *, ...)
 
 static const int verbosity = -1;
 
+#define PRINTLN(...) \
+  do { \
+  } while (0)
+
 #define acquire_message_lock() \
   do { \
   } while (0)

--- a/tiers.c
+++ b/tiers.c
@@ -1,4 +1,5 @@
 #include "tiers.h"
+#include "message.h"
 #include "ring.h"
 #include "utilities.h"
 


### PR DESCRIPTION
Fixes compile error when configured with --quiet:

```
tiers.c: In function ‘recalculate_tier_limits’:
tiers.c:50:3: error: implicit declaration of function ‘very_verbose’ [-Wimplicit-function-declaration]
   50 |   very_verbose (ring,
      |   ^~~~~~~~~~~~
tiers.c: In function ‘print_tiers_bumped_statistics’:
tiers.c:65:3: error: implicit declaration of function ‘PRINTLN’ [-Wimplicit-function-declaration]
   65 |   PRINTLN ("%-22s %17" PRIu64 " %13.2f %% per bumped",
      |   ^~~~~~~
```